### PR TITLE
Pick the window you would like to merge into the current one

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,6 +5,9 @@ class windowManager {
     this.windowHistory[false] = { previous: browser.windows.WINDOW_ID_NONE, current: browser.windows.WINDOW_ID_NONE };
     this.contextMenus = {};
 
+    browser.commands.onCommand.addListener(command => {
+      this.handleCommand(command);
+    });
     browser.contextMenus.onClicked.addListener((info, tab) => {
       this.merge(this.contextMenus[info.menuItemId], tab.windowId);
     });
@@ -12,6 +15,20 @@ class windowManager {
       this.calculateContextMenu();
     });
     this.calculateContextMenu();
+  }
+
+  async handleCommand(command) {
+    const currentWindow = await browser.windows.getCurrent();
+    let target = browser.windows.WINDOW_ID_NONE;
+    if (command === 'merge-all-windows') {
+      target = Infinity;
+    }
+    if (command === 'merge-previous-window') {
+      target = this.windowHistory[currentWindow.incognito].previous;
+    }
+    if (target !== browser.windows.WINDOW_ID_NONE) {
+      this.merge(target, currentWindow.id);
+    }
   }
 
   async getCurrentWindows() {

--- a/manifest.json
+++ b/manifest.json
@@ -14,5 +14,18 @@
 
   "background": {
     "scripts": ["background.js"]
+  },
+
+  "commands": {
+    "merge-all-windows": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+M",
+        "mac": "MacCtrl+Shift+M"
+      },
+      "description": "Merge all windows into the current one."
+    },
+    "merge-previous-window": {
+      "description": "Merge previously focused window into the current one."
+    }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -18,10 +18,6 @@
 
   "commands": {
     "merge-all-windows": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+M",
-        "mac": "MacCtrl+Shift+M"
-      },
       "description": "Merge all windows into the current one."
     },
     "merge-previous-window": {


### PR DESCRIPTION
Fixes #1. Maybe.

This tries to follow @jonathanKingston’s https://github.com/jonathanKingston/merge-windows/issues/1#issuecomment-312727603 by leaving a “Merge all windows” to work as it does today, while optionally introducing “Merge with […]” options to the menu. All the options are moved to a submenu for the extension.

The list of window options is sorted so that the first option is the previously focused window, for easy merging. (It does not remember a full history so the rest of the list is unsorted.)

This does not (yet) introduce keyboard shortcuts, though I do want to get working on those as well.

![Screenshot: showing the open context menu with 2 different windows to choose from.](https://user-images.githubusercontent.com/490579/63230499-ceb76680-c20d-11e9-83f1-09d7964ddc8d.png)

Change to the current merging algorithm: it no longer merges windows into the one with the most tabs. Instead if will merge into the current window.